### PR TITLE
Return internal server error when API is unhealthy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ python:
 install:
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
-script: nosetests tests/unit
+script: pytest tests/unit

--- a/flask_management_blueprint/management/management_resource.py
+++ b/flask_management_blueprint/management/management_resource.py
@@ -1,8 +1,10 @@
 """Resource to manage api settings"""
+from http import HTTPStatus
 from flask import jsonify
 from flask import Blueprint, render_template, abort
 from .app_info import AppInfo
 from .health_check import HealthCheck
+from .health_status import OK
 
 
 def setup_blueprint():
@@ -22,4 +24,6 @@ def health_check():
     """Returns general informations about the health of the application"""
     info = AppInfo.app_info()
     info['Components'] = HealthCheck.check_resources_health()
-    return jsonify(info)
+    if info['Status'] != OK[0]:
+        return jsonify(info), HTTPStatus.INTERNAL_SERVER_ERROR
+    return jsonify(info), HTTPStatus.OK

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ lazy-object-proxy==1.3.1
 mccabe==0.6.1
 nose==1.3.7
 pylint==1.8.2
+pytest==5.3.5
 six==1.11.0
 wrapt==1.10.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ chardet==3.0.4
 idna-ssl==1.0.0
 idna==2.6
 multidict==4.1.0
-flask==0.12.2
+flask==1.0
 websockets==4.0.1
 yarl==1.1.1

--- a/samples/requirements.txt
+++ b/samples/requirements.txt
@@ -4,7 +4,7 @@ async-timeout==2.0.1
 attrs==17.4.0
 chardet==3.0.4
 click==6.7
-Flask==0.12.2
+Flask==1.0
 flask-management-blueprint==0.1.0
 idna==2.6
 idna-ssl==1.0.1

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture(scope="package")
+def test_app():
+    from flask import Flask
+    app = Flask(__name__)
+    return app

--- a/tests/unit/management/test_resource.py
+++ b/tests/unit/management/test_resource.py
@@ -1,0 +1,41 @@
+from http import HTTPStatus
+from unittest.mock import patch
+
+from flask_management_blueprint.management import health_status
+from flask_management_blueprint.management import management_resource
+
+
+@patch('flask_management_blueprint.management.management_resource.HealthCheck.check_resources_health')
+@patch('flask_management_blueprint.management.management_resource.AppInfo.app_info')
+def test_health_check_is_ok(mock_app_info, mock_health_check, test_app):
+    with test_app.test_request_context():
+        mock_health_check.return_value = []
+        mock_app_info.return_value = {
+            "ApplicationName": "mock1",
+            "ApplicationType": "mock2",
+            "BuildDate": "mock3",
+            "Version": "mock4",
+            "Status": health_status.OK[0]
+        }
+
+        response = management_resource.health_check()
+
+        assert response[1] is HTTPStatus.OK
+
+
+@patch('flask_management_blueprint.management.management_resource.HealthCheck.check_resources_health')
+@patch('flask_management_blueprint.management.management_resource.AppInfo.app_info')
+def test_health_check_is_not_ok(mock_app_info, mock_health_check, test_app):
+    with test_app.test_request_context():
+        mock_health_check.return_value = []
+        mock_app_info.return_value = {
+            "ApplicationName": "mock1",
+            "ApplicationType": "mock2",
+            "BuildDate": "mock3",
+            "Version": "mock4",
+            "Status": health_status.CRITICAL[0]
+        }
+
+        response = management_resource.health_check()
+
+        assert response[1] is HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
So we can easily check the API health without parse the json body.

![image](https://user-images.githubusercontent.com/20428941/84959603-0ca74480-b0d6-11ea-978b-1715f6f87ccd.png)
